### PR TITLE
CSS Pseudo Classes

### DIFF
--- a/frontend/CSS/pseudo-classes/example.html
+++ b/frontend/CSS/pseudo-classes/example.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>CSS Pseudo-classes Example</title>
+  <style>
+    /* Set initial styles for the box */
+    .box {
+      width: 100px;
+      height: 100px;
+      background-color: red;
+      position: relative;
+      margin: 50px auto;
+      transition: transform 1s;
+    }
+
+    /* Apply different styles when the box is hovered over */
+    .box:hover {
+      background-color: blue;
+      transform: rotate(50deg);
+    }
+
+    /* Apply different styles when the box is clicked */
+    .box:active {
+      background-color: green;
+      transform: scale(1.5);
+    }
+
+
+    /* Apply different styles when the checkbox is checked */
+    input[type="checkbox"]:checked {
+      transform: translateX(200px);
+    }
+
+  </style>
+</head>
+
+<body>
+  <h1>CSS Pseudo-classes Example</h1>
+
+  <!-- Add a checkbox to trigger the :checked pseudo-class -->
+  <label>
+    <input type="checkbox" /> Move checkbox right
+  </label>
+
+  <!-- Add a box to apply the pseudo-classes to -->
+  <div class="box">
+  </div>
+</body>
+
+</html>

--- a/frontend/CSS/pseudo-classes/summary.md
+++ b/frontend/CSS/pseudo-classes/summary.md
@@ -1,0 +1,9 @@
+# Pseudo-classes
+
+CSS pseudo-classes are keywords that can be added to selectors to style elements that are not in a specific state or are not selected by other selectors. Pseudo-classes allow developers to add styles to elements based on user interactions, such as hovering over or clicking on an element, or based on the state of an element, such as whether it's the first child or last child of its parent.
+
+There are many CSS pseudo-classes available, including :hover, :active, :focus, :checked, :disabled, :nth-child(), and :not(), among others. Each pseudo-class has a specific purpose and can be used to apply different styles to elements in different states.
+
+CSS pseudo-classes can be used in conjunction with other selectors to create more specific and targeted styles. For example, you can use the :hover pseudo-class with the a selector to apply a specific style to links when the user hovers over them.
+
+Overall, CSS pseudo-classes are a powerful tool for adding interactivity and dynamic styling to web pages, and can help developers create engaging user experiences.


### PR DESCRIPTION
This PR adds an HTML example and summary of pseudo-classe in CSS. The example includes a 
box element with pseudo classes and a checkbox that triggers the :checked pseudo-class. The CSS styles for each 
pseudo-class are 
defined in head.

- Add summary
- Add example for pseudo-classes
